### PR TITLE
feat: display cache tag errors in a dialog

### DIFF
--- a/src/LeakyCache/DisplayLeakyCache.php
+++ b/src/LeakyCache/DisplayLeakyCache.php
@@ -42,7 +42,7 @@ class DisplayLeakyCache implements LeakyCacheInterface{
   </div>
   <div style="padding: 0 20px 20px;">
     <p>The following entity cache tags are missing from the response:</p>
-    <ul>
+    <ul style="margin: 0">
       <li><pre>
       {$tags_markup}
       </pre></li>


### PR DESCRIPTION
Show the errors in a dialog.

![image](https://github.com/user-attachments/assets/3e92844a-dd2b-4ad4-9b38-198d232ef607)

Note: this PR requires #4 