### PR TITLE
fix(entity tracking): skip ContentModerationState entities

### DIFF
--- a/cmc.module
+++ b/cmc.module
@@ -10,6 +10,7 @@ declare(strict_types=1);
 use Drupal\cmc\EntityCacheTagCollector;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\content_moderation\Entity\ContentModerationState;
 
 /**
  * Implements hook_entity_load().
@@ -28,4 +29,15 @@ function cmc_entity_load(array $entities, $entity_type_id) {
       $entity->getConfigDependencyKey() === 'content'
   );
   array_map([$entity_cache_tag_collector, 'registerLoadedEntity'], $content_entities);
+}
+
+/**
+ * Implements hook_cmc_skip_tracking().
+ */
+function cmc_cmc_skip_tracking(EntityInterface $entity): bool {
+  if ($entity instanceof ContentModerationState) {
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/cmc.module
+++ b/cmc.module
@@ -8,9 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\cmc\EntityCacheTagCollector;
-use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\content_moderation\Entity\ContentModerationState;
 
 /**
  * Implements hook_entity_load().
@@ -29,15 +27,4 @@ function cmc_entity_load(array $entities, $entity_type_id) {
       $entity->getConfigDependencyKey() === 'content'
   );
   array_map([$entity_cache_tag_collector, 'registerLoadedEntity'], $content_entities);
-}
-
-/**
- * Implements hook_cmc_skip_tracking().
- */
-function cmc_cmc_skip_tracking(EntityInterface $entity): bool {
-  if ($entity instanceof ContentModerationState) {
-    return true;
-  } else {
-    return false;
-  }
 }

--- a/src/EntityCacheTagCollector.php
+++ b/src/EntityCacheTagCollector.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\cmc;
 
+use Drupal\content_moderation\Entity\ContentModerationStateInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 
@@ -41,6 +42,10 @@ class EntityCacheTagCollector {
    *   TRUE if this entity should be tracked, FALSE otherwise.
    */
   private function shouldTrack(EntityInterface $entity): bool {
+    // There are certain entities we won't track by default.
+    if ($entity instanceof ContentModerationStateInterface) {
+      return FALSE;
+    }
     // Allow modules to modify this.
     $skip = $this->moduleHandler->invokeAll('cmc_skip_tracking', [$entity]);
     // If at least one module wants to skip the tracking, bail out.


### PR DESCRIPTION
When a site has workflow module enabled, `content_moderation_state` entities are loaded, thus leading to this module expecting them to be present in cache tags. These tags are not actually present from Drupal's response, so we should skip tracking them.

<img width="483" height="203" alt="Screenshot 2025-09-23 at 1 05 48 PM" src="https://github.com/user-attachments/assets/de1c70d6-d7af-4059-b180-413d3ca99c13" />

<img width="472" height="819" alt="Screenshot 2025-09-23 at 1 18 10 PM" src="https://github.com/user-attachments/assets/b5d12a8c-9ae3-4d78-a201-964048681db1" />
