### PR TITLE
Dont track users on user_login_form submission

### DIFF
--- a/cmc.services.yml
+++ b/cmc.services.yml
@@ -1,7 +1,10 @@
 services:
   _defaults:
     autowire: true
-  Drupal\cmc\EntityCacheTagCollector: { }
+  Drupal\cmc\EntityCacheTagCollector:
+    arguments:
+      - '@module_handler'
+      - '@request_stack'
   Drupal\cmc\EventSubscriber\LoadedEntitySubscriber:
     tags:
       - { name: event_subscriber }

--- a/src/EntityCacheTagCollector.php
+++ b/src/EntityCacheTagCollector.php
@@ -5,6 +5,8 @@ namespace Drupal\cmc;
 use Drupal\content_moderation\Entity\ContentModerationStateInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class EntityCacheTagCollector {
 
@@ -15,7 +17,10 @@ class EntityCacheTagCollector {
    */
   private array $tagsFromLoadedEntities = [];
 
-  public function __construct(private readonly ModuleHandlerInterface $moduleHandler) {}
+  public function __construct(
+    private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly RequestStack $requestStack,
+  ) {}
 
   /**
    * Registers cache tags for a given entity.
@@ -45,6 +50,13 @@ class EntityCacheTagCollector {
     // There are certain entities we won't track by default.
     if ($entity instanceof ContentModerationStateInterface) {
       return FALSE;
+    }
+
+    if ($entity instanceof User) {
+      $request = $this->requestStack->getCurrentRequest();
+      if ($request && $request->request->get('form_id') === 'user_login_form') {
+        return FALSE;
+      }
     }
     // Allow modules to modify this.
     $skip = $this->moduleHandler->invokeAll('cmc_skip_tracking', [$entity]);


### PR DESCRIPTION
When logging in, `UserAuthentication` calls `$this->entityTypeManager->getStorage('user')->loadByProperties(['name' => $username]);`

This loads the user entity, calling cmc's hook_entity_load and adding the `user:X` tag to its list of expected tags. If the password is wrong, however, the tag shouldn't be present. This PR skips tracking `user` entities specifically on requests to user_login_form.