### PR TITLE
Remove instruction needing custom composer repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,17 @@ verifying their cache tags are properly bubbled up to the response.
 
 ## Getting Started
 
-1. Add this repository to your composer.json:
-   ```bash
-   composer config repositories.cmc --json '{"type": "vcs", "url": "git@github.com:Lullabot/cmc.git"}'
-   ```
-
-2. Set minimum stability to dev (if needed):
+1. Set minimum stability to dev (if needed):
    ```bash
    composer config minimum-stability dev
    ```
 
-3. Require the module:
+2. Require the module:
    ```bash
    composer require lullabot/cmc
    ```
 
-4. Enable the module:
+3. Enable the module:
    ```bash
    drush en cmc
    ```


### PR DESCRIPTION
Because the module is [available on Packagist](https://packagist.org/packages/lullabot/cmc), there's no need for a custom repository config.