### PR TITLE
Allow ruleset.xml to be more flexible in reusability

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -4,7 +4,4 @@
 
   <!-- Include our custom sniffs -->
   <rule ref="./Sniffs/Twig/DirectFieldAccessSniff.php"/>
-
-  <!-- Define file extensions to check -->
-  <arg name="extensions" value="html.twig"/>
 </ruleset>

--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -4,4 +4,9 @@
 
   <!-- Include our custom sniffs -->
   <rule ref="./Sniffs/Twig/DirectFieldAccessSniff.php"/>
+
+  <rule ref="Internal.NoCodeFound">
+    <!-- Empty files are fine, might be used for testing. -->
+    <exclude-pattern>*</exclude-pattern>
+  </rule>
 </ruleset>


### PR DESCRIPTION
Related: #15 

When using this ruleset, it means my phpcs will *only* scan twig files anymore, despite what I have configured it to scan in my root phpcs.xml.dist file due to this setting in the project's ruleset.xml:

```xml
<arg name="extensions" value="html.twig"/>
```

There's already a check in DirectFieldAccessSniff for the file type to ensure it doesn't process any non-twig files, so we should be able to remove that argument:

```php
  /**
   * {@inheritdoc}
   */
  public function process(File $phpcsFile, $stackPtr) {
    // Only process .twig files.
    $fileExtension = strtolower(substr($phpcsFile->getFilename(), -5));
    if ($fileExtension !== '.twig') {
      return;
    }
    ...
  }
```